### PR TITLE
Error during restore

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -114,20 +114,21 @@ insert_block_ui.dag_board <- function(
 #'
 #' @param id Block id to show
 #' @param parent Parent reactive values.
+#' @param refreshed Reactive value to indicate if the board has been refreshed.
 #' @param session Shiny session object.
 #' @rdname block-panel
-show_block_panel <- function(id, parent, session) {
+show_block_panel <- function(id, parent, refreshed, session) {
   ns <- session$ns
 
   # Extract block panels
-  block_panels <- chr_ply(
-    grep("block", get_panels_ids("layout"), value = TRUE),
-    \(pane) {
-      strsplit(pane, "block-")[[1]][2]
-    }
+  all_panels <- get_panels_ids("layout", session)
+  block_panels <- gsub(
+    "block-",
+    "",
+    grep("block", all_panels, value = TRUE)
   )
   # Don't do anything if the block panel is already there
-  if (parent$selected_block %in% block_panels) {
+  if (!refreshed && parent$selected_block %in% block_panels) {
     return(NULL)
   }
 
@@ -143,12 +144,12 @@ show_block_panel <- function(id, parent, session) {
       # the linked block UIs and causes many issues.
       renderer = "always",
       position = list(
-        referencePanel = if (length(get_panels_ids("layout")) == 2) {
+        referencePanel = if (length(all_panels) == 2) {
           "dag"
         } else {
-          get_panels_ids("layout")[length(get_panels_ids("layout"))]
+          all_panels[length(all_panels)]
         },
-        direction = if (length(get_panels_ids("layout")) == 2) {
+        direction = if (length(all_panels) == 2) {
           "below"
         } else {
           "within"

--- a/R/utils-board.R
+++ b/R/utils-board.R
@@ -299,13 +299,55 @@ build_layout <- function(modules, plugins) {
     output <- session$output
     ns <- session$ns
 
-    # TBD: re-insert block panel ui if it was closed
+    refreshed <- reactiveVal(FALSE)
+
+    # Cleanup existing panels on restore
     observeEvent(
       {
-        req(parent$selected_block, length(parent$selected_block) == 1)
+        req(parent$refreshed == "network")
       },
       {
-        show_block_panel(parent$selected_block, parent, session)
+        block_panels <- gsub(
+          "block-",
+          "",
+          grep(
+            "block",
+            get_panels_ids("layout", session),
+            value = TRUE
+          )
+        )
+        remove_block_panels(block_panels)
+        refreshed(TRUE)
+      }
+    )
+
+    # Show block panel on board refresh if there was a selected block
+    observeEvent(
+      req(
+        refreshed() &&
+          !length(grep("block-", get_panels_ids("layout", session)))
+      ),
+      {
+        if (!length(parent$selected_block)) {
+          return(NULL)
+        }
+        show_block_panel(parent$selected_block, parent, TRUE, session)
+        refreshed(FALSE)
+      }
+    )
+
+    # Re-insert block panel ui if it was closed any time a block is selected.
+    # This work only for single selection (for now). TBD: I think we could easily loop
+    # over multiple selected blocks and show them all.
+    observeEvent(
+      {
+        req(
+          parent$selected_block,
+          length(parent$selected_block) == 1
+        )
+      },
+      {
+        show_block_panel(parent$selected_block, parent, FALSE, session)
       }
     )
 

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -79,24 +79,31 @@ remove_blk_from_dashboard <- function(id, session) {
   output[[out_name]] <- NULL
 }
 
-#' @export
-#' @rdname restore-dashboard
-restore_dashboard.dag_board <- function(board, rv, parent, session) {
-  # cleanup old state
-  if (length(parent$in_grid)) {
-    lapply(names(parent$in_grid), \(id) {
+#'@keywords internal
+cleanup_dashboard <- function(session) {
+  # cleanup existing dock panels
+  panel_ids <- get_panels_ids("dock", session)
+  if (length(panel_ids)) {
+    panel_ids <- gsub("block-", "", panel_ids)
+    lapply(panel_ids, \(id) {
       remove_blk_from_dashboard(id, session)
     })
   }
+}
+
+#' @export
+#' @rdname restore-dashboard
+restore_dashboard.dag_board <- function(board, rv, parent, session) {
   parent$in_grid <- list()
   ids <- names(rv$blocks)
+  # Find blocks that should be in the dock
+  in_grid_ids <- find_blocks_ids(rv$board, parent, session)
 
+  # Don't restore if no blocks
   if (!length(ids)) {
     parent$refreshed <- "grid"
     return(NULL)
   }
-
-  in_grid_ids <- find_blocks_ids(rv$board, parent, session)
 
   # When the dock was empty, we still need to initialise the block state
   # and all values are false
@@ -110,9 +117,9 @@ restore_dashboard.dag_board <- function(board, rv, parent, session) {
   # Otherwise we spread elements between the dock and the network
   not_in_grid <- which(!(ids %in% in_grid_ids))
 
+  # Regenerate the output for the block as well as dock panel
   lapply(in_grid_ids, \(id) {
     parent$in_grid[[id]] <- TRUE
-    # Regenerate the output for the block as well as dock panel
     generate_dashboard_blk_output(id, rv, session)
     add_blk_panel_to_dashboard(id, rv, session)
   })
@@ -148,7 +155,7 @@ find_blocks_ids.dag_board <- function(
   if (!length(state) || !length(state$panels)) {
     return(NULL)
   }
-  chr_ply(strsplit(names(state$panels), "block-"), `[[`, 2L)
+  gsub("block-", "", names(state$panels))
 }
 
 #' Update dashboard zoom on the client

--- a/man/block-panel.Rd
+++ b/man/block-panel.Rd
@@ -5,7 +5,7 @@
 \alias{hide_block_panel}
 \title{Show a block panel}
 \usage{
-show_block_panel(id, parent, session)
+show_block_panel(id, parent, refreshed, session)
 
 hide_block_panel(id, session)
 }
@@ -13,6 +13,8 @@ hide_block_panel(id, session)
 \item{id}{Block id to show}
 
 \item{parent}{Parent reactive values.}
+
+\item{refreshed}{Reactive value to indicate if the board has been refreshed.}
 
 \item{session}{Shiny session object.}
 }

--- a/tests/testthat/test-board.R
+++ b/tests/testthat/test-board.R
@@ -144,7 +144,12 @@ testServer(
 
     # Refresh
     dot_args$parent$refreshed <- "network"
-    session$flushReact()
+    # Manually setup the dashboard state as this is theoretically
+    # injected by the dashboard module
+    dot_args$parent$module_state$dashboard <- reactiveVal(NULL)
+    # Manually simulate remove panel as the JS callback does not work
+    # in the testServer context
+    session$setInputs(dock_state = list(panels = list()))
     expect_identical(dot_args$parent$refreshed, "grid")
 
     # Scoutbar


### PR DESCRIPTION
Fixes #85

- I had to decouple few observers to give enough time to dockViewR to update its state, so that the subsequent observers play with the right state (and not an outdated version). Finally dockViewR is working well, its just how Shiny works.

- Also added code to cleanup the main layout from block panels.

---

For follow-up PR: there is repetition in the code: `remove_blk_from_dashboard`, `remove_block_panels` moreless do the same thing. I also don't like how the panel name is constructed (sometimes with "block-", sometimes not ... this is crap). I'll rework that in another PR as this was not introduced by this one.