### PR TITLE
Pin blockr.core to PR #176 to align with downstream Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,6 @@ Suggests:
     testthat (>= 3.0.0),
     withr
 Remotes:
-    BristolMyersSquibb/blockr.core#176
+    BristolMyersSquibb/blockr.core#178
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,6 @@ Suggests:
     testthat (>= 3.0.0),
     withr
 Remotes:
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core#176
 Config/testthat/edition: 3
 VignetteBuilder: knitr


### PR DESCRIPTION
## Summary

- blockr.dock#130 pins blockr.core to PR #176 (the one that adds the `update_stack` generic). With blockr.ui in the import graph and pinning blockr.core to plain main via its own `Remotes:`, the transitive resolution conflicts and pak refuses to install.
- Pin blockr.ui's `Remotes:` to the same PR (#176) so both pins agree. Drop the pin together with blockr.dock once #176 lands.

Fixes #3