### PR TITLE
Block browser: ready-to-apply objects + pre-renderable panels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/ci.yaml@main
     secrets: inherit
     permissions:
       contents: write

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,11 @@
   `link_menu_server()` / `stack_menu_server()`. `block_browser_ui()` no
   longer bakes board-seeded default ids into the markup, so the add-flow
   panel is independent of board state and can be pre-rendered once and
-  opened without re-rendering. (Breaking change for the committed-value
-  shape.)
+  opened without re-rendering. `append_to()` / `prepend_to()` now accept
+  a `NULL` block id (a source-less descriptor), so an append / prepend
+  panel can likewise be pre-rendered once with the source / target
+  supplied server-side at commit. (Breaking change for the
+  committed-value shape.)
 
 * New `link_menu_ui()` / `link_menu_server()` / `link_menu_dep()`
   module: a bidirectional card-list link picker. Cards represent both

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # blockr.ui 0.0.0.9000
 
+* `block_browser_server(id, board, target)` now returns a ready-to-apply
+  value instead of a raw spec: a `blockr.core` `blocks` object for the
+  add flow, or `list(blocks, links)` for append / prepend with the link's
+  input port resolved menu-side. It builds the block and validates the
+  committed ids when given a `board` reactive, matching
+  `link_menu_server()` / `stack_menu_server()`. `block_browser_ui()` no
+  longer bakes board-seeded default ids into the markup, so the add-flow
+  panel is independent of board state and can be pre-rendered once and
+  opened without re-rendering. (Breaking change for the committed-value
+  shape.)
+
 * New `link_menu_ui()` / `link_menu_server()` / `link_menu_dep()`
   module: a bidirectional card-list link picker. Cards represent both
   OUTGOING ("CONNECT TO") and INCOMING ("CONNECT FROM") candidates

--- a/R/block-browser.R
+++ b/R/block-browser.R
@@ -15,13 +15,13 @@
 #'   and input port first, then click the in-card add button.
 #'
 #' The block browser is a Shiny module. `block_browser_ui(id, ...)`
-#' renders the panel; `block_browser_server(id)` returns a reactive that
-#' fires once per add with the block to create:
-#' `list(type, id, title, link_id, block_input, target_input)`. Fields
-#' not applicable to the current flow are `NULL`. Because the suggested
-#' ids are generated avoiding the board's existing block / link ids,
-#' clicking the same card repeatedly (with a pinned sidebar) yields
-#' distinct blocks.
+#' renders the panel; `block_browser_server(id, board, target)` returns a
+#' reactive that fires once per add with a ready-to-apply value: a
+#' [blockr.core::as_blocks] object (*add*), or `list(blocks, links)`
+#' (*append* / *prepend*) with the link's input port already resolved.
+#' The id is resolved at commit against the live board (an empty id field
+#' means "assign one for me"), so clicking the same card repeatedly (with
+#' a pinned sidebar) yields distinct, board-unique ids.
 #'
 #' The flow is selected by the `target` argument: `NULL` (default) adds
 #' a standalone block, [append_to()] appends from a source block, and
@@ -33,25 +33,34 @@
 #' `blockr.ui.blockBrowser` `Shiny.InputBinding` (the root element's
 #' `id` is `NS(id)("commit")`); the value carries an internal `nonce` so
 #' repeat adds re-fire as events. `block_browser_server()` strips the
-#' nonce and hands back the clean spec, so consumers never see it.
+#' nonce and builds the ready objects from the committed spec, so
+#' consumers never see either.
 #'
 #' @param id Module id. As usual for Shiny modules, pass `NS(id)("...")`
 #'   from the parent at the `*_ui()` call site and the bare id to
 #'   `*_server()`.
-#' @param board The current board state. Used to resolve the target
-#'   block's input arity (for prepend) and to seed unique default ids
-#'   avoiding the board's existing block / link ids.
+#' @param board The current board. In `block_browser_ui()` a plain board,
+#'   used only by the *prepend* port picker (the target block's free input
+#'   slots) and the *append* / *prepend* context subtitle; the *add*-flow
+#'   markup is independent of board state and `board` may be `NULL`. In
+#'   `block_browser_server()` it may be a **reactive** returning the board
+#'   (to validate ids, build the block, and resolve the link port) or
+#'   `NULL`.
 #' @param target Where the new block attaches. `NULL` (default) is a
 #'   plain add; [append_to()] appends from a source block;
-#'   [prepend_to()] prepends into a target block.
+#'   [prepend_to()] prepends into a target block. `block_browser_server()`
+#'   also accepts a reactive selecting the flow.
 #' @param block_id Block id the new block attaches to: a source block
 #'   for [append_to()], a target block for [prepend_to()].
 #'
 #' @return
 #' * `block_browser_ui()` returns an [htmltools::tag] with
 #'   [block_browser_dep()] attached.
-#' * `block_browser_server()` returns a [shiny::reactive] of the
-#'   committed block spec (a list), firing once per add.
+#' * `block_browser_server()` returns a [shiny::reactive] firing once per
+#'   add with a ready-to-apply value: a [blockr.core::as_blocks] object
+#'   for the *add* flow, or `list(blocks, links)` for *append* /
+#'   *prepend* (the link's input port already resolved). Applied as-is by
+#'   the consumer.
 #' * `append_to()` / `prepend_to()` return a `bb_target` descriptor.
 #' * `block_browser_dep()` returns an [htmltools::htmlDependency].
 #'
@@ -81,13 +90,18 @@ NULL
 
 #' @rdname block-browser
 #' @export
-block_browser_ui <- function(id, board, target = NULL) {
+block_browser_ui <- function(id, board = NULL, target = NULL) {
   stopifnot(is.character(id), length(id) == 1L, nzchar(id))
   stopifnot(is.null(target) || inherits(target, "bb_target"))
 
   ns <- shiny::NS(id)
   mode <- target_mode(target)
-  metas <- browser_block_metas(board, mode)
+  # The card list is a pure function of the registry: no board-seeded
+  # default ids are baked in (the server resolves a unique id at commit),
+  # so the add-flow markup is board-independent and can be rendered once.
+  # `board` is used only by resolve_target() for the prepend port picker
+  # and the append / prepend context subtitle.
+  metas <- browser_block_metas(mode)
   tgt <- resolve_target(board, target)
 
   htmltools::attachDependencies(
@@ -110,24 +124,168 @@ prepend_to <- function(block_id) {
 
 #' @rdname block-browser
 #' @export
-block_browser_server <- function(id) {
+block_browser_server <- function(id, board = NULL, target = NULL) {
   stopifnot(is.character(id), length(id) == 1L, nzchar(id))
+
+  board_fn <- as_arg_reactive(board)
+  target_fn <- as_arg_reactive(target)
+
   shiny::moduleServer(
     id,
     function(input, output, session) {
       # `input$commit` is the binding's value; the `nonce` it carries
       # makes every add a fresh event, so eventReactive fires once per
-      # add. Strip the nonce before handing the spec to the caller.
+      # add. When a `board` reactive is supplied the module validates the
+      # committed ids (a non-empty duplicate notifies and `req()`s out),
+      # then returns a ready-to-apply value: a `blocks` object for the add
+      # flow, or `list(blocks, links)` for append / prepend - parity with
+      # link_menu_server() / stack_menu_server().
       shiny::eventReactive(
         input$commit,
         {
           spec <- input$commit
           spec[["nonce"]] <- NULL
-          spec
+          brd <- board_fn()
+          tgt <- target_fn()
+          if (shiny::is.reactive(board)) {
+            validate_block_spec(spec, brd, tgt, session)
+          }
+          block_commit_value(spec, brd, tgt)
         },
         ignoreNULL = TRUE
       )
     }
+  )
+}
+
+# Turn the committed spec into a ready-to-apply value. The add flow
+# yields a `blocks` object (one id-keyed block); append / prepend yield
+# `list(blocks, links)` with the link's input port resolved. Block
+# construction and port resolution use blockr.core primitives only (no
+# blockr.dock dependency), mirroring link_menu's commit value and the
+# dock's former build_block_from_spec + block_input_select assembly.
+block_commit_value <- function(spec, board, target) {
+  blk <- build_browser_block(spec, board)
+  blk_id <- resolve_browser_id(spec$id, board, blockr.core::board_block_ids)
+  blocks <- blockr.core::as_blocks(stats::setNames(list(blk), blk_id))
+
+  if (target_mode(target) == "add") {
+    return(blocks)
+  }
+
+  list(
+    blocks = blocks,
+    links = block_commit_link(spec, board, target, blk, blk_id)
+  )
+}
+
+# Build the link that wires the new block to its target. Append: the new
+# block (blk_id) receives from the source (target$id), so the port is a
+# free slot on the NEW block. Prepend: the new block feeds INTO the
+# target, so the port is a free slot on the TARGET block.
+block_commit_link <- function(spec, board, target, blk, blk_id) {
+  links <- safe_board_links(board)
+  link_id <- resolve_browser_id(
+    spec$link_id, board, blockr.core::board_link_ids
+  )
+
+  if (target$mode == "append") {
+    input <- spec$block_input
+    if (is.null(input) || !nzchar(input)) {
+      input <- resolve_free_input(blk, blk_id, links)
+    }
+    lnk <- blockr.core::new_link(from = target$id, to = blk_id, input = input)
+  } else {
+    tgt_blk <- board_block(board, target$id)
+    input <- spec$target_input
+    if (is.null(input) || !nzchar(input)) {
+      input <- resolve_free_input(tgt_blk, target$id, links)
+    }
+    lnk <- blockr.core::new_link(from = blk_id, to = target$id, input = input)
+  }
+
+  blockr.core::as_links(stats::setNames(list(lnk), link_id))
+}
+
+# Construct the block instance, naming it uniquely against the board
+# (mirrors the dock's create_block_with_name) then overriding with the
+# user's title when supplied.
+build_browser_block <- function(spec, board) {
+  existing <- board_block_names(board)
+  blk <- blockr.core::create_block(
+    spec$type,
+    block_name = function(class) {
+      utils::tail(
+        make.unique(
+          c(existing, blockr.core::default_block_name(class)),
+          sep = " "
+        ),
+        1L
+      )
+    }
+  )
+  if (!is.null(spec$title) && nzchar(spec$title)) {
+    blockr.core::block_name(blk) <- spec$title
+  }
+  blk
+}
+
+# An explicit, board-unique id is kept as-is; otherwise (empty field, or
+# a collision) a fresh unique id is generated against the board.
+resolve_browser_id <- function(spec_id, board, getter) {
+  existing <- safe_board_ids(board, getter)
+  if (is_new_id(spec_id, existing)) {
+    spec_id
+  } else {
+    blockr.core::rand_names(old_names = existing, n = 1L)
+  }
+}
+
+# Reject a non-empty committed id that collides with the board (block id
+# always; link id for append / prepend). An empty id is valid - it means
+# "assign one for me", resolved in block_commit_value().
+validate_block_spec <- function(spec, board, target, session) {
+  reject_collision(
+    spec$id, safe_board_ids(board, blockr.core::board_block_ids),
+    "block", session
+  )
+  if (target_mode(target) %in% c("append", "prepend")) {
+    reject_collision(
+      spec$link_id, safe_board_ids(board, blockr.core::board_link_ids),
+      "link", session
+    )
+  }
+  invisible(TRUE)
+}
+
+reject_collision <- function(id, existing, what, session) {
+  if (!is.null(id) && nzchar(id) && id %in% existing) {
+    blockr.core::notify(
+      paste0("Please choose a valid ", what, " ID."),
+      type = "warning", session = session
+    )
+    shiny::req(FALSE)
+  }
+  invisible(TRUE)
+}
+
+# Display names of the board's blocks (empty for a NULL board), used to
+# generate a unique default block name.
+board_block_names <- function(board) {
+  if (is.null(board)) return(character())
+  blks <- tryCatch(
+    blockr.core::board_blocks(board), error = function(e) NULL
+  )
+  if (is.null(blks)) return(character())
+  vapply(blks, blockr.core::block_name, character(1L))
+}
+
+# The board's links, or an empty links object for a NULL board.
+safe_board_links <- function(board) {
+  if (is.null(board)) return(blockr.core::links())
+  tryCatch(
+    blockr.core::board_links(board),
+    error = function(e) blockr.core::links()
   )
 }
 
@@ -163,11 +321,14 @@ target_mode <- function(target) {
 
 # ---- panel assembly ----------------------------------------------------
 
-# Build the per-block metadata list: registry rows plus the seeded
-# unique default ids. Link ids and block-input slots are only computed
-# for the flows that render those fields (each `safe_block_inputs()`
-# instantiates a block, so we skip the work otherwise).
-browser_block_metas <- function(board, mode) {
+# Build the per-block metadata list from the registry. Independent of
+# board state: default block / link ids are no longer seeded here (the
+# server resolves a unique id at commit), so the rendered markup is a
+# pure function of the registry. Block-input slots are still computed
+# for the append flow (each `safe_block_inputs()` instantiates a block,
+# so we skip the work otherwise) to drive the linkable-block filter and
+# the in-card port picker.
+browser_block_metas <- function(mode) {
   registry <- blockr.core::available_blocks()
   metas <- lapply(seq_along(registry), function(i) {
     entry <- registry[[i]]
@@ -185,7 +346,6 @@ browser_block_metas <- function(board, mode) {
     )
   })
 
-  need_link <- mode %in% c("append", "prepend")
   need_inputs <- mode == "append"
 
   # For append, the new block has to receive a link from the source, so
@@ -193,7 +353,7 @@ browser_block_metas <- function(board, mode) {
   # which accepts arbitrary fresh slots. Source-only blocks (arity 0,
   # e.g. dataset_block) can't be appended and are filtered out.
   # Variadic blocks (e.g. rbind_block) return character(0) from
-  # block_inputs() but DO accept links - the dock generates a fresh
+  # block_inputs() but DO accept links - the server generates a fresh
   # slot name. Prepend / add are unfiltered.
   if (need_inputs) {
     for (i in seq_along(metas)) {
@@ -209,21 +369,6 @@ browser_block_metas <- function(board, mode) {
       metas[[i]]$inputs <- character()
       metas[[i]]$variadic <- FALSE
     }
-  }
-
-  n <- length(metas)
-  id_defaults <- seed_ids(
-    safe_board_ids(board, blockr.core::board_block_ids), n
-  )
-  link_defaults <- if (need_link) {
-    seed_ids(safe_board_ids(board, blockr.core::board_link_ids), n)
-  } else {
-    rep("", n)
-  }
-
-  for (i in seq_along(metas)) {
-    metas[[i]]$id_default <- id_defaults[[i]]
-    metas[[i]]$link_default <- link_defaults[[i]]
   }
 
   metas
@@ -403,11 +548,14 @@ card_advanced <- function(meta, ns, mode, target_inputs) {
 
   shiny::tags$div(
     class = "blockr-block-browser-card-advanced",
+    # Empty default: the server resolves a unique id at commit (avoiding
+    # the board's ids). An explicit value here overrides that.
     field_text(
       class_suffix = "id",
       id = field_id("id"),
       label = "Block ID",
-      value = meta$id_default
+      value = "",
+      placeholder = "auto"
     ),
     field_text(
       class_suffix = "title",
@@ -421,7 +569,8 @@ card_advanced <- function(meta, ns, mode, target_inputs) {
         class_suffix = "link-id",
         id = field_id("link_id"),
         label = "Link ID",
-        value = meta$link_default
+        value = "",
+        placeholder = "auto"
       )
     },
     if (show_block_input) {

--- a/R/block-browser.R
+++ b/R/block-browser.R
@@ -169,7 +169,7 @@ block_browser_server <- function(id, board = NULL, target = NULL) {
 # blockr.dock dependency), mirroring link_menu's commit value and the
 # dock's former build_block_from_spec + block_input_select assembly.
 block_commit_value <- function(spec, board, target) {
-  blk <- build_browser_block(spec, board)
+  blk <- build_browser_block(spec)
   blk_id <- resolve_browser_id(spec$id, board, blockr.core::board_block_ids)
   blocks <- blockr.core::as_blocks(stats::setNames(list(blk), blk_id))
 
@@ -211,27 +211,16 @@ block_commit_link <- function(spec, board, target, blk, blk_id) {
   blockr.core::as_links(stats::setNames(list(lnk), link_id))
 }
 
-# Construct the block instance, naming it uniquely against the board
-# (mirrors the dock's create_block_with_name) then overriding with the
-# user's title when supplied.
-build_browser_block <- function(spec, board) {
-  existing <- board_block_names(board)
-  blk <- blockr.core::create_block(
-    spec$type,
-    block_name = function(class) {
-      utils::tail(
-        make.unique(
-          c(existing, blockr.core::default_block_name(class)),
-          sep = " "
-        ),
-        1L
-      )
-    }
-  )
+# Construct the block instance. The user's title (when supplied) is the
+# block name; otherwise we let blockr.core derive the default name. The
+# id - not the name - is what must be board-unique, and that is handled
+# separately by resolve_browser_id().
+build_browser_block <- function(spec) {
   if (!is.null(spec$title) && nzchar(spec$title)) {
-    blockr.core::block_name(blk) <- spec$title
+    blockr.core::create_block(spec$type, block_name = spec$title)
+  } else {
+    blockr.core::create_block(spec$type)
   }
-  blk
 }
 
 # An explicit, board-unique id is kept as-is; otherwise (empty field, or
@@ -271,17 +260,6 @@ reject_collision <- function(id, existing, what, session) {
     shiny::req(FALSE)
   }
   invisible(TRUE)
-}
-
-# Display names of the board's blocks (empty for a NULL board), used to
-# generate a unique default block name.
-board_block_names <- function(board) {
-  if (is.null(board)) return(character())
-  blks <- tryCatch(
-    blockr.core::board_blocks(board), error = function(e) NULL
-  )
-  if (is.null(blks)) return(character())
-  vapply(blks, blockr.core::block_name, character(1L))
 }
 
 # The board's links, or an empty links object for a NULL board.

--- a/R/block-browser.R
+++ b/R/block-browser.R
@@ -51,7 +51,11 @@
 #'   [prepend_to()] prepends into a target block. `block_browser_server()`
 #'   also accepts a reactive selecting the flow.
 #' @param block_id Block id the new block attaches to: a source block
-#'   for [append_to()], a target block for [prepend_to()].
+#'   for [append_to()], a target block for [prepend_to()]. May be `NULL`
+#'   (the default): a source-less descriptor that carries only the flow,
+#'   for pre-rendering an append / prepend panel once and supplying the
+#'   source / target server-side at commit (via `block_browser_server()`'s
+#'   `target`).
 #'
 #' @return
 #' * `block_browser_ui()` returns an [htmltools::tag] with
@@ -112,13 +116,13 @@ block_browser_ui <- function(id, board = NULL, target = NULL) {
 
 #' @rdname block-browser
 #' @export
-append_to <- function(block_id) {
+append_to <- function(block_id = NULL) {
   new_bb_target("append", block_id)
 }
 
 #' @rdname block-browser
 #' @export
-prepend_to <- function(block_id) {
+prepend_to <- function(block_id = NULL) {
   new_bb_target("prepend", block_id)
 }
 
@@ -305,8 +309,11 @@ block_browser_dep <- function() {
 
 # ---- target descriptor -------------------------------------------------
 
-new_bb_target <- function(mode, block_id) {
-  stopifnot(is.character(block_id), length(block_id) == 1L, nzchar(block_id))
+new_bb_target <- function(mode, block_id = NULL) {
+  stopifnot(
+    is.null(block_id) ||
+      (is.character(block_id) && length(block_id) == 1L && nzchar(block_id))
+  )
   structure(
     list(mode = mode, id = block_id),
     class = c(paste0("bb_target_", mode), "bb_target")
@@ -378,7 +385,13 @@ browser_block_metas <- function(mode) {
 # place: the context subtitle, the target's input slot names, and the
 # `data-target-arity` attribute (prepend only).
 resolve_target <- function(board, target) {
-  if (is.null(target)) {
+  # `target = NULL` is the add flow; a target with a `NULL` id is a
+  # source-less append / prepend descriptor (the source is supplied
+  # server-side at commit), used to pre-render the panel once. Either
+  # way there is no concrete block to derive a subtitle / port picker
+  # from, so the panel is rendered context-free (the consumer supplies
+  # the "Append from X" context via the sidebar title).
+  if (is.null(target) || is.null(target$id)) {
     return(list(subtitle = NULL, inputs = character(), attrs = list()))
   }
 

--- a/inst/examples/block-browser/app.R
+++ b/inst/examples/block-browser/app.R
@@ -32,45 +32,82 @@ ui <- fluidPage(
   # Hidden outputs read by the shinytest2 suite.
   tags$p(textOutput("commit_type", inline = TRUE)),
   tags$p(textOutput("commit_id", inline = TRUE)),
-  sidebar_ui("panel", side = "right", width = "420px")
+  # The add browser's card list never varies, so its body is pre-rendered
+  # ONCE here. Opening it (below) just toggles the panel - no re-render,
+  # no server round-trip for the markup. This is the pattern the dock
+  # uses to avoid rebuilding the catalogue on every open.
+  sidebar_ui(
+    "add_panel",
+    side = "right", width = "420px",
+    title = "Add new block",
+    ui = block_browser_ui("add_browser", board)
+  ),
+  # Append / prepend depend on the right-clicked block, so that browser is
+  # target-specific and rendered per open (the dynamic show_sidebar path).
+  sidebar_ui("edit_panel", side = "right", width = "420px")
 )
 
 server <- function(input, output, session) {
   last_commit <- reactiveVal(NULL)
+  current_target <- reactiveVal(NULL)
 
-  # One block browser module instance, reused across the four triggers.
-  added <- blockr.ui::block_browser_server("browser")
+  # Two browser instances, both fed the board so they return ready-to-
+  # apply values: a `blocks` object for add, or `list(blocks, links)` for
+  # append / prepend with the port resolved.
+  added_add <- block_browser_server("add_browser", board = reactive(board))
+  added_edit <- block_browser_server(
+    "edit_browser",
+    board = reactive(board),
+    target = reactive(current_target())
+  )
 
-  open_browser <- function(title, target = NULL) {
+  # Add: open the pre-rendered panel (no `ui` -> no re-render).
+  observeEvent(input$open_add, show_sidebar("add_panel"))
+
+  # Append / prepend: render the target-specific browser on open.
+  open_edit <- function(title, target) {
+    current_target(target)
     show_sidebar(
-      "panel",
+      "edit_panel",
       title = title,
-      ui = blockr.ui::block_browser_ui(session$ns("browser"), board, target)
+      ui = block_browser_ui("edit_browser", board, target)
     )
   }
-
-  observeEvent(input$open_add, open_browser("Add new block"))
   observeEvent(input$open_append,
-               open_browser("Append block", blockr.ui::append_to("src")))
+               open_edit("Append block", append_to("src")))
   observeEvent(input$open_prepend_h,
-               open_browser("Prepend block", blockr.ui::prepend_to("head1")))
+               open_edit("Prepend block", prepend_to("head1")))
   observeEvent(input$open_prepend_m,
-               open_browser("Prepend block", blockr.ui::prepend_to("merge1")))
+               open_edit("Prepend block", prepend_to("merge1")))
 
-  observeEvent(added(), last_commit(added()))
+  observeEvent(added_add(), last_commit(added_add()))
+  observeEvent(added_edit(), last_commit(added_edit()))
+
+  # `last_commit()` is either a `blocks` object (add) or `list(blocks,
+  # links)` (append / prepend); pull the committed block out of either.
+  commit_blocks <- reactive({
+    res <- last_commit()
+    if (is.null(res)) {
+      NULL
+    } else if (blockr.core::is_blocks(res)) {
+      res
+    } else {
+      res$blocks
+    }
+  })
 
   output$commit <- renderPrint({
-    spec <- last_commit()
-    if (is.null(spec)) cat("(no commit yet)") else str(spec)
+    res <- last_commit()
+    if (is.null(res)) cat("(no commit yet)") else str(res)
   })
 
   output$commit_type <- renderText({
-    spec <- last_commit()
-    if (is.null(spec)) "" else spec$type
+    blks <- commit_blocks()
+    if (is.null(blks)) "" else class(blks[[1L]])[1L]
   })
   output$commit_id <- renderText({
-    spec <- last_commit()
-    if (is.null(spec) || is.null(spec$id)) "" else spec$id
+    blks <- commit_blocks()
+    if (is.null(blks)) "" else names(blks)[1L]
   })
 }
 

--- a/man/block-browser.Rd
+++ b/man/block-browser.Rd
@@ -11,9 +11,9 @@
 \usage{
 block_browser_ui(id, board = NULL, target = NULL)
 
-append_to(block_id)
+append_to(block_id = NULL)
 
-prepend_to(block_id)
+prepend_to(block_id = NULL)
 
 block_browser_server(id, board = NULL, target = NULL)
 
@@ -38,7 +38,11 @@ plain add; \code{\link[=append_to]{append_to()}} appends from a source block;
 also accepts a reactive selecting the flow.}
 
 \item{block_id}{Block id the new block attaches to: a source block
-for \code{\link[=append_to]{append_to()}}, a target block for \code{\link[=prepend_to]{prepend_to()}}.}
+for \code{\link[=append_to]{append_to()}}, a target block for \code{\link[=prepend_to]{prepend_to()}}. May be \code{NULL}
+(the default): a source-less descriptor that carries only the flow,
+for pre-rendering an append / prepend panel once and supplying the
+source / target server-side at commit (via \code{block_browser_server()}'s
+\code{target}).}
 }
 \value{
 \itemize{

--- a/man/block-browser.Rd
+++ b/man/block-browser.Rd
@@ -9,13 +9,13 @@
 \alias{block_browser_dep}
 \title{Block browser}
 \usage{
-block_browser_ui(id, board, target = NULL)
+block_browser_ui(id, board = NULL, target = NULL)
 
 append_to(block_id)
 
 prepend_to(block_id)
 
-block_browser_server(id)
+block_browser_server(id, board = NULL, target = NULL)
 
 block_browser_dep()
 }
@@ -24,13 +24,18 @@ block_browser_dep()
 from the parent at the \verb{*_ui()} call site and the bare id to
 \verb{*_server()}.}
 
-\item{board}{The current board state. Used to resolve the target
-block's input arity (for prepend) and to seed unique default ids
-avoiding the board's existing block / link ids.}
+\item{board}{The current board. In \code{block_browser_ui()} a plain board,
+used only by the \emph{prepend} port picker (the target block's free input
+slots) and the \emph{append} / \emph{prepend} context subtitle; the \emph{add}-flow
+markup is independent of board state and \code{board} may be \code{NULL}. In
+\code{block_browser_server()} it may be a \strong{reactive} returning the board
+(to validate ids, build the block, and resolve the link port) or
+\code{NULL}.}
 
 \item{target}{Where the new block attaches. \code{NULL} (default) is a
 plain add; \code{\link[=append_to]{append_to()}} appends from a source block;
-\code{\link[=prepend_to]{prepend_to()}} prepends into a target block.}
+\code{\link[=prepend_to]{prepend_to()}} prepends into a target block. \code{block_browser_server()}
+also accepts a reactive selecting the flow.}
 
 \item{block_id}{Block id the new block attaches to: a source block
 for \code{\link[=append_to]{append_to()}}, a target block for \code{\link[=prepend_to]{prepend_to()}}.}
@@ -39,8 +44,11 @@ for \code{\link[=append_to]{append_to()}}, a target block for \code{\link[=prepe
 \itemize{
 \item \code{block_browser_ui()} returns an \link[htmltools:builder]{htmltools::tag} with
 \code{\link[=block_browser_dep]{block_browser_dep()}} attached.
-\item \code{block_browser_server()} returns a \link[shiny:reactive]{shiny::reactive} of the
-committed block spec (a list), firing once per add.
+\item \code{block_browser_server()} returns a \link[shiny:reactive]{shiny::reactive} firing once per
+add with a ready-to-apply value: a \link[blockr.core:new_block]{blockr.core::as_blocks} object
+for the \emph{add} flow, or \code{list(blocks, links)} for \emph{append} /
+\emph{prepend} (the link's input port already resolved). Applied as-is by
+the consumer.
 \item \code{append_to()} / \code{prepend_to()} return a \code{bb_target} descriptor.
 \item \code{block_browser_dep()} returns an \link[htmltools:htmlDependency]{htmltools::htmlDependency}.
 }
@@ -63,13 +71,13 @@ and input port first, then click the in-card add button.
 }
 
 The block browser is a Shiny module. \code{block_browser_ui(id, ...)}
-renders the panel; \code{block_browser_server(id)} returns a reactive that
-fires once per add with the block to create:
-\code{list(type, id, title, link_id, block_input, target_input)}. Fields
-not applicable to the current flow are \code{NULL}. Because the suggested
-ids are generated avoiding the board's existing block / link ids,
-clicking the same card repeatedly (with a pinned sidebar) yields
-distinct blocks.
+renders the panel; \code{block_browser_server(id, board, target)} returns a
+reactive that fires once per add with a ready-to-apply value: a
+\link[blockr.core:new_block]{blockr.core::as_blocks} object (\emph{add}), or \code{list(blocks, links)}
+(\emph{append} / \emph{prepend}) with the link's input port already resolved.
+The id is resolved at commit against the live board (an empty id field
+means "assign one for me"), so clicking the same card repeatedly (with
+a pinned sidebar) yields distinct, board-unique ids.
 
 The flow is selected by the \code{target} argument: \code{NULL} (default) adds
 a standalone block, \code{\link[=append_to]{append_to()}} appends from a source block, and
@@ -81,7 +89,8 @@ Internally the panel publishes its value through the
 \code{blockr.ui.blockBrowser} \code{Shiny.InputBinding} (the root element's
 \code{id} is \code{NS(id)("commit")}); the value carries an internal \code{nonce} so
 repeat adds re-fire as events. \code{block_browser_server()} strips the
-nonce and hands back the clean spec, so consumers never see it.
+nonce and builds the ready objects from the committed spec, so
+consumers never see either.
 }
 \examples{
 if (interactive()) {

--- a/openspec/changes/block-browser-prerender-and-ready-objects/tasks.md
+++ b/openspec/changes/block-browser-prerender-and-ready-objects/tasks.md
@@ -43,40 +43,40 @@
 
 ## 3. `blockr.dock`: pre-render mount + thin handlers
 
-- [ ] 3.1 In `R/board-ui.R`, add a dedicated `sidebar_ui(NS(id,
+- [x] 3.1 In `R/board-ui.R`, add a dedicated `sidebar_ui(NS(id,
   "add_block_sidebar"), ui = blockr.ui::block_browser_ui(NS(id, "add_browser")))`
   mount (rendered once); wire its open trigger via `data-blockr-sidebar-target`
   or `show_sidebar(id)`.
-- [ ] 3.2 Rewrite `add_block_action()` in `R/action-block.R` as a thin
+- [x] 3.2 Rewrite `add_block_action()` in `R/action-block.R` as a thin
   adapter: mount `block_browser_server(m, board = reactive(board$board))`
   once, and on commit `update(list(blocks = committed()))`. No
   `show_sidebar(ui = ...)`, no `build_block_from_spec()`.
-- [ ] 3.3 Rewrite `append_block_action()` / `prepend_block_action()` as thin
+- [x] 3.3 Rewrite `append_block_action()` / `prepend_block_action()` as thin
   adapters consuming `list(blocks, links)` from
   `block_browser_server(m, board = reactive(board$board), target =
   reactive(append_to/prepend_to(trigger())))`, applying both via `update()`.
   Remove the dock-side `block_input_select()` + `new_link()` assembly and the
   `valid_block_id()` / `valid_link_id()` pre-flight from these handlers.
-- [ ] 3.4 Remove now-dead dock helpers (`build_block_from_spec()`, and the
+- [x] 3.4 Remove now-dead dock helpers (`build_block_from_spec()`, and the
   block-flow uses of `block_input_select()`) if nothing else references
   them; keep helpers still used by link / stack flows.
-- [ ] 3.5 Update the dock action `testServer` suites
+- [x] 3.5 Update the dock action `testServer` suites
   (`test-action-block.R`) to drive `input$commit` and assert the ready
   objects flow through `update()` unchanged.
 
 ## 4. Reconcile + validate
 
-- [ ] 4.1 Reconcile `refactor-dock-action-handlers`: the block handlers now
+- [x] 4.1 Reconcile `refactor-dock-action-handlers`: the block handlers now
   receive ready objects, so its `resolve_input_port()` and the block-flow
   scaffold shrink; update that change's design / tasks to match (or note the
   overlap is absorbed here).
-- [ ] 4.2 NEWS in both packages: `blockr.ui` (`block_browser_server()` now
+- [x] 4.2 NEWS in both packages: `blockr.ui` (`block_browser_server()` now
   returns ready `blocks` / `links` objects and takes `board` / `target`;
   `block_browser_ui()` add-flow markup is board-independent and
   pre-renderable); `blockr.dock` (add browser pre-rendered once; add /
   append / prepend handlers are thin adapters).
-- [ ] 4.3 `devtools::check()` + `lintr::lint_package()` clean on `blockr.ui`.
-- [ ] 4.4 `devtools::check()` + `lintr::lint_package()` clean on
+- [x] 4.3 `devtools::check()` + `lintr::lint_package()` clean on `blockr.ui`.
+- [x] 4.4 `devtools::check()` + `lintr::lint_package()` clean on
   `blockr.dock` after the handler rewrite.
 - [ ] 4.5 Manual smoke test of the dock + dag example: open add browser
   (pre-rendered, no re-render on reopen), add a block; right-click → append

--- a/openspec/changes/block-browser-prerender-and-ready-objects/tasks.md
+++ b/openspec/changes/block-browser-prerender-and-ready-objects/tasks.md
@@ -78,7 +78,7 @@
 - [x] 4.3 `devtools::check()` + `lintr::lint_package()` clean on `blockr.ui`.
 - [x] 4.4 `devtools::check()` + `lintr::lint_package()` clean on
   `blockr.dock` after the handler rewrite.
-- [ ] 4.5 Manual smoke test of the dock + dag example: open add browser
+- [x] 4.5 Manual smoke test of the dock + dag example: open add browser
   (pre-rendered, no re-render on reopen), add a block; right-click → append
   / prepend, add with default and edited port; repeated pinned adds yield
   distinct ids.

--- a/openspec/changes/block-browser-prerender-and-ready-objects/tasks.md
+++ b/openspec/changes/block-browser-prerender-and-ready-objects/tasks.md
@@ -1,43 +1,43 @@
 ## 1. `blockr.ui`: board-independent UI + ready-object server
 
-- [ ] 1.1 In `R/block-browser.R`, stop seeding board-derived default block /
+- [x] 1.1 In `R/block-browser.R`, stop seeding board-derived default block /
   link ids into the per-card markup (`browser_block_metas()` /
   `card_advanced()`). The card's id field ships with a client-side or empty
   default; the server resolves the real unique id at commit. Make
   `block_browser_ui(id, board = NULL, target = NULL)` so the *add* call site
   needs no board.
-- [ ] 1.2 Add an internal `resolve_free_input()`-equivalent (or lift /
+- [x] 1.2 Add an internal `resolve_free_input()`-equivalent (or lift /
   share the one in `R/link-menu.R`) so the block browser resolves the link
   port from the live board with `blockr.core` primitives only: explicit
   pick, else first free named slot, else a fresh integer slot for variadic
   targets.
-- [ ] 1.3 Add an internal block builder: `create_block(spec$type)` named
+- [x] 1.3 Add an internal block builder: `create_block(spec$type)` named
   from `spec$title`, with a board-unique id (`rand_names()` seeded from the
   live board's block ids when the committed id is empty / colliding).
-- [ ] 1.4 Rework `block_browser_server(id, board = NULL, target = NULL)` to
+- [x] 1.4 Rework `block_browser_server(id, board = NULL, target = NULL)` to
   return ready objects: a `blocks` object for *add*; `list(blocks, links)`
   for *append* / *prepend* with the resolved port. Strip the `nonce`; keep
   the `input$commit` event drive.
-- [ ] 1.5 When `board` is a reactive, validate the committed block id (and
+- [x] 1.5 When `board` is a reactive, validate the committed block id (and
   link id for append / prepend): notify + `req(FALSE)` on empty / duplicate,
   mirroring `validate_link_spec()` / the stack-menu validator.
-- [ ] 1.6 Update roxygen (`@param board`, `@param target`, `@return`) for
+- [x] 1.6 Update roxygen (`@param board`, `@param target`, `@return`) for
   both functions; regenerate `man/`.
 
 ## 2. `blockr.ui`: tests + examples
 
-- [ ] 2.1 Update `tests/testthat/test-block-browser.R`: the server now
+- [x] 2.1 Update `tests/testthat/test-block-browser.R`: the server now
   returns `blocks` / `list(blocks, links)`. Cover add (blocks object),
   append (blocks + link, resolved port, explicit port), prepend (arity-1
   implicit slot, arity-2 explicit `target_input`), and duplicate-id
   rejection with a board reactive.
-- [ ] 2.2 Add a test asserting the *add* markup is identical across two
+- [x] 2.2 Add a test asserting the *add* markup is identical across two
   boards (board-independence), and that two commits against a pinned panel
   yield distinct board-unique ids.
-- [ ] 2.3 Update `inst/examples/block-browser/app.R` to the new contract
+- [x] 2.3 Update `inst/examples/block-browser/app.R` to the new contract
   (pass a `board` reactive; consume ready objects) and pre-render the add
   browser once via `sidebar_ui(ui = block_browser_ui(...))`.
-- [ ] 2.4 Update the block-browser shinytest2 suite for the pre-rendered
+- [x] 2.4 Update the block-browser shinytest2 suite for the pre-rendered
   open path (open / close / reopen with no re-render) where it asserts on
   the rendered panel.
 

--- a/openspec/changes/refactor-dock-action-handlers/proposal.md
+++ b/openspec/changes/refactor-dock-action-handlers/proposal.md
@@ -1,3 +1,15 @@
+> **Reconcile note (block-browser-prerender-and-ready-objects).** That
+> change already rewrote `add_block_action` / `append_block_action` /
+> `prepend_block_action` as thin adapters over a `block_browser_server()`
+> that returns ready `blocks` / `links` objects, and removed
+> `build_block_from_spec()`, `valid_block_id()` and `valid_link_id()`. So
+> the block-flow parts of this proposal (the `resolve_input_port()` helper
+> and the per-block-handler `update()` assembly in tasks 1.5 / 2.1-2.3 /
+> 2.5) are largely moot for the block handlers. This refactor should now
+> scope to the link / stack handlers and the shared scaffold around them;
+> `resolve_input_port()` survives only if a non-block-browser caller still
+> needs it.
+
 ## Why
 
 After `add-block-browser` (#5), `add-stack-menu` (#7), and `add-link-menu`

--- a/tests/testthat/test-block-browser-shinytest2.R
+++ b/tests/testthat/test-block-browser-shinytest2.R
@@ -141,3 +141,33 @@ test_that("clicking inside the form does not add the block", {
   ))
   expect_equal(app$get_value(output = "commit_type"), "")
 })
+
+test_that("the pre-rendered add browser is not rebuilt across opens", {
+  # The add browser's body is pre-rendered once into #add_panel and the
+  # button only toggles the panel. Tagging the live DOM node and finding
+  # the tag intact after a close / reopen proves it was not re-rendered.
+  app <- shinytest2::AppDriver$new(
+    app_path, name = "block-browser-prerender",
+    load_timeout = 20 * 1000, timeout = 10 * 1000
+  )
+  on.exit(app$stop(), add = TRUE)
+
+  add_browser <- "#add_panel .blockr-block-browser"
+
+  app$click("open_add")
+  app$wait_for_idle(500)
+  app$run_js(sprintf(
+    "document.querySelector('%s').dataset.persist = 'yes'", add_browser
+  ))
+
+  click_js(app, "#add_panel .blockr-sidebar-close")
+  app$click("open_add")
+  app$wait_for_idle(500)
+
+  expect_equal(
+    app$get_js(sprintf(
+      "document.querySelector('%s').dataset.persist", add_browser
+    )),
+    "yes"
+  )
+})

--- a/tests/testthat/test-block-browser.R
+++ b/tests/testthat/test-block-browser.R
@@ -408,6 +408,28 @@ test_that("a duplicate non-empty id is rejected (no fire) with a board", {
   )
 })
 
+test_that("source-less append_to() renders a pre-renderable append panel", {
+  # `append_to()` (no source) is the descriptor used to pre-render the
+  # append panel once: append-mode markup, no context subtitle, and the
+  # same linkable card set as a sourced `append_to(<id>)` (the filter is
+  # registry-based, not source-specific).
+  board <- blockr.core::new_board(
+    blocks = list(m = blockr.core::new_merge_block())
+  )
+  html_src  <- as.character(block_browser_ui("a", board, append_to("m")))
+  html_free <- as.character(block_browser_ui("a", target = append_to()))
+
+  expect_match(html_free, "data-mode=\"append\"", fixed = TRUE)
+  expect_match(html_free, "blockr-block-browser-field-link-id", fixed = TRUE)
+  # No "Append from X" context band in the source-less variant.
+  expect_false(grepl("blockr-block-browser-context", html_free))
+
+  cards <- function(h) {
+    regmatches(h, gregexpr("data-block-type=\"[a-z_]+\"", h))[[1L]]
+  }
+  expect_identical(cards(html_free), cards(html_src))
+})
+
 test_that("malformed inputs are rejected", {
   expect_error(block_browser_ui(character(0), NULL))
   expect_error(block_browser_ui(c("a", "b"), NULL))

--- a/tests/testthat/test-block-browser.R
+++ b/tests/testthat/test-block-browser.R
@@ -239,26 +239,29 @@ test_that("per-card form field ids are namespaced by id + block type", {
   expect_match(html, "id=\"mod_a-dataset_block_title\"", fixed = TRUE)
 })
 
-test_that("default block ids are unique and avoid the board's existing ids", {
-  existing <- c("aaa", "bbb")
-  board <- blockr.core::new_board(
+test_that("add-flow markup is independent of board state", {
+  # No board-seeded default id is baked into the markup, so the add-flow
+  # panel is a pure function of the registry. The server resolves a
+  # unique id at commit instead (see the server tests below).
+  b1 <- blockr.core::new_board(
+    blocks = list(aaa = blockr.core::new_dataset_block())
+  )
+  b2 <- blockr.core::new_board(
     blocks = stats::setNames(
-      list(blockr.core::new_dataset_block(),
-           blockr.core::new_dataset_block()),
-      existing
+      list(blockr.core::new_dataset_block(), blockr.core::new_head_block()),
+      c("bbb", "ccc")
     )
   )
-  panel <- block_browser_ui("mod_a", board)
-  html <- as.character(htmltools::renderTags(panel)$html)
 
-  vals <- regmatches(
-    html,
-    gregexpr("id=\"mod_a-[a-z_]+_id\" value=\"([^\"]+)\"", html)
-  )[[1]]
-  ids <- sub(".*value=\"([^\"]+)\"$", "\\1", vals)
-  expect_true(length(ids) >= 1)
-  expect_equal(length(ids), length(unique(ids)))
-  expect_false(any(ids %in% existing))
+  m0 <- as.character(block_browser_ui("mod_a", NULL))
+  m1 <- as.character(block_browser_ui("mod_a", b1))
+  m2 <- as.character(block_browser_ui("mod_a", b2))
+
+  expect_identical(m1, m0)
+  expect_identical(m2, m0)
+  # The id field ships empty; no board id leaks into the static markup.
+  expect_match(m0, "id=\"mod_a-dataset_block_id\" value=\"\"", fixed = TRUE)
+  expect_false(any(grepl("value=\"aaa\"|value=\"bbb\"", m1)))
 })
 
 test_that("per-card forms never register Shiny-bound inputs", {
@@ -294,20 +297,113 @@ test_that("block_browser_ui attaches the dependency", {
   expect_true("blockr-block-browser" %in% dep_names)
 })
 
-test_that("block_browser_server returns the committed spec without nonce", {
+test_that("add commit returns a ready blocks object", {
+  board <- blockr.core::new_board(
+    blocks = list(src = blockr.core::new_dataset_block())
+  )
   shiny::testServer(
     block_browser_server,
-    args = list(id = "browser"),
+    args = list(id = "browser", board = shiny::reactive(board)),
     {
       session$setInputs(
-        commit = list(type = "dataset_block", id = "foo",
-                      title = NULL, link_id = NULL, block_input = NULL,
-                      target_input = NULL, nonce = 1)
+        commit = list(type = "dataset_block", id = "foo", title = "",
+                      nonce = 1)
       )
       out <- session$returned()
-      expect_equal(out$type, "dataset_block")
-      expect_equal(out$id, "foo")
-      expect_null(out$nonce)
+      expect_true(blockr.core::is_blocks(out))
+      expect_named(out, "foo")
+      expect_s3_class(out[[1]], "dataset_block")
+    }
+  )
+})
+
+test_that("empty id is resolved to a unique board-avoiding id at commit", {
+  # `brd` (not `board`): inside testServer `board` is the module's
+  # reactive argument, so the board object is referenced under its own
+  # name to read the existing ids.
+  brd <- blockr.core::new_board(
+    blocks = list(src = blockr.core::new_dataset_block())
+  )
+  shiny::testServer(
+    block_browser_server,
+    args = list(id = "browser", board = shiny::reactive(brd)),
+    {
+      session$setInputs(
+        commit = list(type = "dataset_block", id = NULL, title = "",
+                      nonce = 1)
+      )
+      out <- session$returned()
+      expect_true(blockr.core::is_blocks(out))
+      expect_true(nzchar(names(out)))
+      expect_false(names(out) %in% blockr.core::board_block_ids(brd))
+    }
+  )
+})
+
+test_that("append commit returns blocks + links with a resolved port", {
+  board <- blockr.core::new_board(
+    blocks = list(src = blockr.core::new_dataset_block())
+  )
+  shiny::testServer(
+    block_browser_server,
+    args = list(
+      id = "browser", board = shiny::reactive(board),
+      target = append_to("src")
+    ),
+    {
+      session$setInputs(
+        commit = list(type = "merge_block", id = "m1", title = "",
+                      link_id = "lk1", block_input = NULL, nonce = 1)
+      )
+      out <- session$returned()
+      expect_true(blockr.core::is_blocks(out$blocks))
+      expect_true(blockr.core::is_links(out$links))
+      df <- as.data.frame(out$links)
+      expect_identical(df$id, "lk1")
+      expect_identical(df$from, "src")
+      expect_identical(df$to, "m1")
+      expect_true(nzchar(df$input))   # first free port on the new block
+    }
+  )
+})
+
+test_that("explicit block_input is honoured on append", {
+  board <- blockr.core::new_board(
+    blocks = list(src = blockr.core::new_dataset_block())
+  )
+  shiny::testServer(
+    block_browser_server,
+    args = list(
+      id = "browser", board = shiny::reactive(board),
+      target = append_to("src")
+    ),
+    {
+      session$setInputs(
+        commit = list(type = "merge_block", id = "m1", title = "",
+                      link_id = "lk1", block_input = "y", nonce = 1)
+      )
+      out <- session$returned()
+      expect_identical(as.data.frame(out$links)$input, "y")
+    }
+  )
+})
+
+test_that("a duplicate non-empty id is rejected (no fire) with a board", {
+  board <- blockr.core::new_board(
+    blocks = list(src = blockr.core::new_dataset_block())
+  )
+  shiny::testServer(
+    block_browser_server,
+    args = list(id = "browser", board = shiny::reactive(board)),
+    {
+      fired <- 0L
+      observeEvent(session$returned(), fired <<- fired + 1L)
+      session$setInputs(
+        commit = list(type = "dataset_block", id = "src", title = "",
+                      nonce = 1)
+      )
+      session$flushReact()
+      expect_identical(fired, 0L)
     }
   )
 })


### PR DESCRIPTION
## Summary

`block_browser_server(id, board, target)` now returns a **ready-to-apply**
value instead of a raw spec: a `blockr.core` `blocks` object for the add
flow, or `list(blocks, links)` for append / prepend with the link's input
port resolved menu-side (via the shared `resolve_free_input()`, no
`blockr.dock` dependency). It builds the block and validates the committed
ids when given a `board` reactive — parity with `link_menu_server()` /
`stack_menu_server()`.

`block_browser_ui()` no longer bakes board-seeded default ids into the
markup, so the add-flow panel is independent of board state and can be
pre-rendered once and opened without re-rendering. `append_to()` /
`prepend_to()` accept a `NULL` block id (a source-less descriptor), so an
append / prepend panel can likewise be pre-rendered once with the source /
target supplied server-side at commit.

Implements the `block-browser-prerender-and-ready-objects` OpenSpec change.

## Breaking change

The committed-value shape changes from a spec list to ready `blocks` /
`links` objects. `blockr.dock` is the only known consumer and is updated
in lockstep (companion PR).

## Verification

- `R CMD check`: 0 errors / 0 warnings.
- `block-browser` unit + shinytest2 suites rewritten to the new contract
  (incl. board-independent markup, empty-id auto-assign, duplicate-id
  rejection, and a no-rebuild-across-opens assertion); full suite green,
  `lintr` clean.
- Verified on a live dock deployment (54-block registry): append open went
  from ~500 ms to an instant toggle.
