### PR TITLE
fix: re-bind sidebar body inputs on open

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # blockr.ui 0.0.0.9000
 
+* `sidebar_ui()` panels now re-bind their body inputs/outputs on open
+  (`Shiny.bindAll`). `hidePanel` unbinds on close, so a pre-rendered
+  panel opened via `show_sidebar(id)` with no `ui` (no body swap) stayed
+  unbound after its first close and silently stopped emitting. This broke
+  the add / append block browser, which could only commit once.
+
 * `block_browser_server(id, board, target)` now returns a ready-to-apply
   value instead of a raw spec: a `blockr.core` `blocks` object for the
   add flow, or `list(blocks, links)` for append / prepend with the link's

--- a/inst/assets/js/blockr-sidebar.js
+++ b/inst/assets/js/blockr-sidebar.js
@@ -154,6 +154,16 @@
     var body = getBody(panel);
     if (!body) return;
 
+    // Re-bind the body's inputs/outputs on open. `hidePanel` unbinds on
+    // close so a hidden panel doesn't hold stale bindings, but a
+    // pre-rendered panel opened via `show_sidebar(id)` with no `ui` never
+    // swaps its body (the only other place that re-binds), so after its
+    // first close its bindings would stay dead and it would silently stop
+    // emitting (e.g. the add / append block browser committing only once).
+    // `bindAll` skips already-bound nodes, so this is a no-op on the first
+    // open and right after a body-swap show.
+    Shiny.bindAll(body);
+
     // Remember previously-focused element so close can restore it.
     panel._blockrSidebarPreviousActive = document.activeElement;
 


### PR DESCRIPTION
## Symptom

The add / append block browser can only commit once. The first add/append works; reopening the sidebar and committing a second block silently does nothing.

## Cause

Pre-rendered sidebars (#15) are opened as a pure toggle via `show_sidebar(id)` with no `ui`. The JS lifecycle didn't support that:

- `hidePanel` calls `Shiny.unbindAll(body)` on every close, tearing down the block-browser binding's `COMMIT_EVENT` listener.
- `openPanel` only got bindings from `swapBody` (the `show_sidebar(ui = ...)` path). The open-only path never re-bound.

So after the first close the browser was unbound: clicking a card still dispatched `COMMIT_EVENT`, but with no listener Shiny never read `getValue`, `input$commit` never updated, and `added()` never fired again. Prepend was unaffected because it passes `ui = browser_ui()` on every open.

## Fix

`openPanel` now calls `Shiny.bindAll(body)`. It skips already-bound nodes, so it's a no-op on the first open and right after a body-swap show, and re-arms the binding after a prior close. Symmetric with the `unbindAll` in `hidePanel`.

## Verification

Drove `blockr.dock` `inst/examples/empty/app.R` headlessly through two full open -> commit -> R-hide -> reopen -> commit cycles:

- commit 1: `dataset_block`, nonce 1, dock tabs 1 -> 2
- R hid the unpinned sidebar (`openClass: FALSE`) -> real unbind path exercised
- commit 2: `filebrowser_block`, nonce 2, dock tabs 2 -> 3

Before the fix the second commit stalled at nonce 1 with no new tab. Sidebar tests pass (103 PASS, 0 FAIL).