### PR TITLE
Resolve variadic link inputs to a positional slot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     shiny
 Suggests:
     blockr.dock,
+    chromote,
     DBI,
     dbplyr,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # blockr.ui 0.0.0.9000
 
+* `link_menu_server()` and the block browser now resolve a variadic
+  target's new-link input to an empty (positional) slot rather than a
+  generated integer name (`"1"`, `"2"`, ...). This aligns with
+  blockr.core's name-or-position variadic input model, where an integer
+  input is a *named* argument - so the old convention quietly named what
+  should be positional.
+
 * `sidebar_ui()` panels now re-bind their body inputs/outputs on open
   (`Shiny.bindAll`). `hidePanel` unbinds on close, so a pre-rendered
   panel opened via `show_sidebar(id)` with no `ui` (no body swap) stayed

--- a/R/link-menu.R
+++ b/R/link-menu.R
@@ -194,22 +194,14 @@ link_commit_value <- function(spec, board) {
 
 # Pick the target's input slot for a new link, mirroring blockr.dock's
 # `block_input_select(mode = "inputs")` with only blockr.core primitives:
-# the first free named input, or - for a variadic target - a freshly
-# generated numeric slot.
+# the first free named input, or - for a variadic target - an empty
+# (positional) slot, per core's name-or-position input model.
 resolve_free_input <- function(block, block_id, links) {
   curr <- links[links$to == block_id]$input
   free <- setdiff(blockr.core::block_inputs(block), curr)
 
   if (is.na(blockr.core::block_arity(block))) {
-    num <- suppressWarnings(as.integer(curr))
-    num <- num[!is.na(num)]
-    slot <- if (!length(num)) {
-      "1"
-    } else {
-      mis <- setdiff(seq_len(max(num)), num)
-      as.character(if (length(mis)) min(mis) else max(num) + 1L)
-    }
-    free <- c(free, slot)
+    free <- c(free, "")
   }
 
   free[1L]

--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -1,0 +1,44 @@
+# CI hardening for the chromote-driven shinytest2 e2e tests.
+
+# Give Chrome longer to open its remote-debugging port. chromote's default is
+# 10s (`getOption("chromote.timeout", 10)` in launch_chrome_impl), too short on
+# loaded CI runners -- Windows especially -- where launch intermittently aborts
+# with "Chrome debugging port not open after 10 seconds". Scoped to the suite
+# so the option is restored when testing finishes.
+withr::local_options(
+  chromote.timeout = 30,
+  .local_envir = testthat::teardown_env()
+)
+
+# Chrome leaves scratch dirs (com.google.Chrome.* / org.chromium.Chromium.*,
+# scoped_dir variants included) in the session temp parent (`$TMPDIR`), which
+# R CMD check then flags as "detritus in the temp directory" -- a NOTE the CI
+# gate fails on. `app$stop()` only ends the shinytest2 session; the shared
+# browser stays alive until R exits, so its scratch is never reclaimed. At the
+# end of the suite, close the browser (a clean shutdown reclaims its scratch),
+# then sweep anything that still leaked -- but only what this run created, so a
+# shared `$TMPDIR` on a developer machine keeps its other dirs.
+local({
+
+  pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
+  tmp_parent <- dirname(tempdir())
+  before <- list.files(tmp_parent, pattern = pat)
+
+  withr::defer(
+    {
+      if (isTRUE(chromote::has_default_chromote_object())) {
+        try(chromote::default_chromote_object()$close(), silent = TRUE)
+      }
+
+      unlink(
+        file.path(
+          tmp_parent,
+          setdiff(list.files(tmp_parent, pattern = pat), before)
+        ),
+        recursive = TRUE,
+        force = TRUE
+      )
+    },
+    testthat::teardown_env()
+  )
+})

--- a/tests/testthat/test-link-menu.R
+++ b/tests/testthat/test-link-menu.R
@@ -423,7 +423,7 @@ test_that("server resolves the first free named input when none is picked", {
   )
 })
 
-test_that("server generates a numeric slot for a variadic target", {
+test_that("server resolves a variadic target to a positional slot", {
   board <- variadic_board()
   shiny::testServer(
     link_menu_server,
@@ -433,9 +433,23 @@ test_that("server generates a numeric slot for a variadic target", {
         source = "a", target = "r", link_id = "lk", nonce = 1L
       ))
       session$flushReact()
-      expect_identical(session$returned()$input, "1")
+      expect_identical(session$returned()$input, "")
     }
   )
+})
+
+test_that("resolve_free_input gives a variadic target a positional slot", {
+  blocks <- blockr.core::board_blocks(variadic_board())
+
+  expect_identical(
+    resolve_free_input(blocks[["r"]], "r", blockr.core::links()),
+    ""
+  )
+
+  # A variadic target that already carries a positional link resolves to
+  # another positional slot, never a generated integer name.
+  wired <- blockr.core::links(id = "ar", from = "a", to = "r", input = "1")
+  expect_identical(resolve_free_input(blocks[["r"]], "r", wired), "")
 })
 
 test_that("link_sync_payload tracks eligibility across a board change", {


### PR DESCRIPTION
## Summary

- `resolve_free_input()` gave a variadic target's new-link input a generated integer slot (`"1"`, `"2"`, ...). Under blockr.core's name-or-position variadic model an integer input is a *named* argument, so this quietly named what should be positional.
- Resolve a variadic target to an empty (positional) slot instead — wiring order then becomes the argument order. Both `link_menu_server()` and the block browser's auto-link go through `resolve_free_input()`, so this covers both.
- Localized to slot resolution: the `has_input_capacity()` / `free_named_inputs()` eligibility helpers were already correct (a variadic target always accepts, and exposes no named port). Parallel to blockr.dock's editor alignment in BristolMyersSquibb/blockr.dock#275.

Validated against core's name-or-position model — which is now on core `main` (core#211 and dock#276 have merged), so no dependency pins are needed.

## CI unblock (separate commit)

`ci / smoke` on blockr.ui had been red since mid-June, unrelated to this change: R CMD check flags a "detritus in the temp directory" NOTE because the shinytest2 tests leak `com.google.Chrome.*` scratch into `$TMPDIR`, fatal under the smoke job's `error-on: note`. One commit adds the `tests/testthat/setup-chrome-ci.R` teardown blockr.core already carries (close the shared browser + sweep only this run's scratch; raise `chromote.timeout`) and declares `chromote` in Suggests. Happy to split it into its own PR if you'd rather keep this one to the link-menu change.

Fixes #19