### PR TITLE
Table preview: render a NULL result as the empty state, not a crash

### DIFF
--- a/R/table-preview-engine.R
+++ b/R/table-preview-engine.R
@@ -34,6 +34,17 @@
 #' @export
 table_page <- function(result, sort_state = NULL, page = 1L, page_size = 5L,
                        cache = new.env(parent = emptyenv())) {
+  # A NULL result -- a source block with nothing selected yet (e.g. an empty
+  # read block) evaluates its expression to NULL -- has no rows to page.
+  # Return an empty page so nrow(NULL) / colnames(NULL) never propagate a
+  # zero-length/NA value into the slice arithmetic below (which would crash
+  # the whole preview with "missing value where TRUE/FALSE needed"); the
+  # downstream builder renders it as the ordinary "No rows" empty state.
+  if (is.null(result)) {
+    return(list(dat = data.frame(), total_rows = 0L, page = 1L,
+                has_more = FALSE))
+  }
+
   col <- sort_state$col
   dir <- sort_state$dir
   # `dir` must be one of the known sort states. Anything else -- NULL, NA, or a

--- a/R/table-preview-render.R
+++ b/R/table-preview-render.R
@@ -29,6 +29,13 @@ html_table_render <- function(result, session, page_size = 5L) {
   prev_sort <- NULL
 
   shiny::renderUI({
+    # A NULL result means the block is not configured yet (e.g. an empty read
+    # block). Render nothing so the preview area is simply blank -- the block's
+    # own inputs (e.g. a required-empty field) carry the "needs input" cue.
+    if (is.null(result)) {
+      return(NULL)
+    }
+
     out_name <- tryCatch(
       shiny::getCurrentOutputInfo(session)$name,
       error = function(e) NULL

--- a/tests/testthat/test-table-engine.R
+++ b/tests/testthat/test-table-engine.R
@@ -83,6 +83,18 @@ test_that("empty frames work", {
   expect_equal(names(pg$dat), "x")
 })
 
+test_that("a NULL result yields an empty page, not a crash", {
+  # A source block with nothing selected yet (e.g. an empty read block)
+  # evaluates to NULL. That must render as the ordinary empty state, not
+  # crash the preview with "missing value where TRUE/FALSE needed".
+  pg <- expect_no_error(
+    table_page(NULL, list(col = NULL, dir = "none"), 1L, 5L)
+  )
+  expect_equal(pg$total_rows, 0L)
+  expect_equal(nrow(pg$dat), 0L)
+  expect_false(pg$has_more)
+})
+
 test_that("the sort index is cached per (col, dir)", {
   df <- data.frame(x = sample(1e4))
   cache <- new.env(parent = emptyenv())


### PR DESCRIPTION
## Table preview: render a NULL result as the empty state, not a crash

A block that is not configured yet (e.g. an empty read block) evaluates to `NULL`. `table_page(NULL)` hit `nrow(NULL)` / `colnames(NULL)` and crashed the whole preview with *"missing value where TRUE/FALSE needed"*.

This guards `NULL` to an empty page, and renders a `NULL` result as a blank output — so an unconfigured block simply shows nothing rather than an error.

### Changes
- `R/table-preview-engine.R` — `table_page()` NULL guard → empty page
- `R/table-preview-render.R` — blank render on NULL result
- `tests/testthat/test-table-engine.R` — coverage for the NULL path

### Notes
- This is **not** the same as a 0-row real dataset: a real empty file still previews as the normal "No rows" table; only an unconfigured (NULL) block goes blank.
- Tests: 537 passing / 0 failing.

### Related
This is the crash-guard half of the blockr.io empty read-block empty-state work — see BristolMyersSquibb/blockr.io#31. The amber "needs a value" field over there works standalone, but the blank-preview-on-NULL behaviour lives here.
